### PR TITLE
fix missing buildessential_packages var when skipped

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+# file: build-essential/defaults/main.yml
+
+buildessential_packages: []


### PR DESCRIPTION
If this role is a dependency of another role, but is skipped, the first `include_vars` task will also be skipped leaving the `buildessential_packages` var undefined, resulting in an error. This creates a default for the `buildessential_packages` var so it doesn't fail.

This happens when using the `ANXS.nginx` role but `nginx_install_method` is `package`.

Should fix https://github.com/ANXS/build-essential/issues/11